### PR TITLE
アカウントに関連したデータ構造の見直し

### DIFF
--- a/docs/shuttlepub-core/data-structure.md
+++ b/docs/shuttlepub-core/data-structure.md
@@ -13,9 +13,17 @@ classDiagram
 		summary: String
 		icon: String
 		banner: String
+		meta_data: Vec[MetaData]
 	}
 	class Follow {
-		target: [AccountId | String]
+		id: ULID
+		target: [AccountId[long] | String]
+	}
+	class MetaData {
+		id: [AccountId[long]]
+		index: long
+		label: String
+		content: String
 	}
 	Account --|> Profile
 	Account --|> Follow

--- a/docs/shuttlepub-core/data-structure.md
+++ b/docs/shuttlepub-core/data-structure.md
@@ -5,6 +5,7 @@ classDiagram
 	class Account {
 		id: long
 		account_name: String
+		is_bot: bool
 		profile: Profile
 		follow: Vec[Follow]
 	}

--- a/docs/shuttlepub-core/data-structure.md
+++ b/docs/shuttlepub-core/data-structure.md
@@ -21,6 +21,7 @@ classDiagram
 		target: [AccountId[long] | String]
 	}
 	class MetaData {
+		id: long
 		label: String
 		content: String
 	}

--- a/docs/shuttlepub-core/data-structure.md
+++ b/docs/shuttlepub-core/data-structure.md
@@ -20,11 +20,12 @@ classDiagram
 		target: [AccountId[long] | String]
 	}
 	class MetaData {
-		id: [AccountId[long]]
+		id: AccountId[long]
 		index: long
 		label: String
 		content: String
 	}
 	Account --|> Profile
 	Account --|> Follow
+	Profile --|> MetaData
 ```

--- a/docs/shuttlepub-core/data-structure.md
+++ b/docs/shuttlepub-core/data-structure.md
@@ -6,6 +6,7 @@ classDiagram
 		id: long
 		account_name: String
 		is_bot: bool
+		confidential: Confidential
 		profile: Profile
 		follow: Vec[Follow]
 	}
@@ -26,6 +27,12 @@ classDiagram
 		label: String
 		content: String
 	}
+	class Confidential {
+		id: AccountId[long]
+		mail: String
+		password: String
+	}
+	Account --|> Confidential
 	Account --|> Profile
 	Account --|> Follow
 	Profile --|> MetaData

--- a/docs/shuttlepub-core/data-structure.md
+++ b/docs/shuttlepub-core/data-structure.md
@@ -6,7 +6,6 @@ classDiagram
 		id: long
 		account_name: String
 		is_bot: bool
-		confidential: Confidential
 		profile: Profile
 		follow: Vec[Follow]
 	}
@@ -27,10 +26,10 @@ classDiagram
 		content: String
 	}
 	class Confidential {
+		id: AccountId[long]
 		mail: String
 		password: String
 	}
-	Account --|> Confidential
 	Account --|> Profile
 	Account --|> Follow
 	Profile --|> MetaData

--- a/docs/shuttlepub-core/data-structure.md
+++ b/docs/shuttlepub-core/data-structure.md
@@ -22,13 +22,11 @@ classDiagram
 		target: [AccountId[long] | String]
 	}
 	class MetaData {
-		id: AccountId[long]
 		index: long
 		label: String
 		content: String
 	}
 	class Confidential {
-		id: AccountId[long]
 		mail: String
 		password: String
 	}

--- a/docs/shuttlepub-core/data-structure.md
+++ b/docs/shuttlepub-core/data-structure.md
@@ -21,7 +21,6 @@ classDiagram
 		target: [AccountId[long] | String]
 	}
 	class MetaData {
-		index: long
 		label: String
 		content: String
 	}


### PR DESCRIPTION
- Accountクラス内にConfidentialクラスを追加
  アカウントのパスワードなどのセンシティブな情報を格納するクラスになります
- Accountクラス内に`is_bot`フラグを追加
- Followクラス内に以前話していたULIDを追加
- AccountDataクラス内にMetaDataクラスを追加
  これはMastodonやMisskeyにもある機能で、各種リンクとかを載せるためのデータになります。
  ![image](https://user-images.githubusercontent.com/39013345/218288294-e38749b0-cdb8-4234-a23c-122b5f36b942.png)
  ActivityPubデータ内の`attachment`に相当します


Signed-off-by: turtton <top.gear7509@turtton.net>